### PR TITLE
Adds type and comment to partition keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,7 @@ module "glue" {
 
     ]
 
-
-    storage_descriptor_ser_de_info  = []
-    storage_descriptor_sort_columns = []
-    storage_descriptor_skewed_info  = [
+    storage_descriptor_ser_de_info  = [
         {
             ser_de_info_name                  = "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"
             ser_de_info_serialization_library = "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"
@@ -79,7 +76,8 @@ module "glue" {
         }
 
     ]
-
+    storage_descriptor_sort_columns = []
+    storage_descriptor_skewed_info  = []
 
     # AWS Glue connection
     enable_glue_connection                                  = true
@@ -222,8 +220,10 @@ module "glue" {
 
 ## Module Output Variables
 ----------------------
+- `glue_catalog_database_arn` - Amazon Resource Name (ARN) for glue catalog database
 - `glue_catalog_database_id` - ID for glue catalog database
 - `glue_catalog_database_name` - Name for glue catalog database
+- `glue_catalog_table_arn` - Amazon Resource Name (ARN) for glue catalog table
 - `glue_catalog_table_id` - ID for glue catalog table
 - `glue_catalog_table_name` - Name for glue catalog table
 - `glue_classifier_id` - Name of the classifier

--- a/glue_catalog_table.tf
+++ b/glue_catalog_table.tf
@@ -21,6 +21,8 @@ resource "aws_glue_catalog_table" "glue_catalog_table" {
         for_each = var.glue_catalog_table_partition_keys
         content {
             name    = lookup(partition_keys.value, "name", null)
+            type    = lookup(partition_keys.value, "type", null)
+            comment = lookup(partition_keys.value, "comment", null)
         }
     }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,10 @@
 #---------------------------------------------------
 # AWS Glue catalog database
 #---------------------------------------------------
+output "glue_catalog_database_arn" {
+    description = "ARN for glue catalog database"
+    value       = element(concat(aws_glue_catalog_database.glue_catalog_database.*.arn, [""]), 0)
+}
 output "glue_catalog_database_id" {
     description = "ID for glue catalog database"
     value       = element(concat(aws_glue_catalog_database.glue_catalog_database.*.id, [""]), 0)
@@ -14,6 +18,10 @@ output "glue_catalog_database_name" {
 #---------------------------------------------------
 # AWS Glue catalog table
 #---------------------------------------------------
+output "glue_catalog_table_arn" {
+    description = "ARN for glue catalog table"
+    value       = element(concat(aws_glue_catalog_table.glue_catalog_table.*.arn, [""]), 0)
+}
 output "glue_catalog_table_id" {
     description = "ID for glue catalog table"
     value       = element(concat(aws_glue_catalog_table.glue_catalog_table.*.id, [""]), 0)


### PR DESCRIPTION
The partition keys definition is skipping the type and comment, so the created partition key in AWS do appear without data type.