### PR TITLE
Update glue_job.tf

### DIFF
--- a/glue_job.tf
+++ b/glue_job.tf
@@ -11,6 +11,7 @@ resource "aws_glue_job" "glue_job" {
   connections            = length(var.glue_job_connections) > 0 ? var.glue_job_connections : (var.enable_glue_connection ? concat(var.glue_job_additional_connections, [element(concat(aws_glue_connection.glue_connection.*.id, [""]), 0)]) : [])
   default_arguments      = var.glue_job_default_arguments
   glue_version           = var.glue_job_glue_version
+  execution_class        = var.glue_job_execution_class
   max_capacity           = var.glue_job_max_capacity
   max_retries            = var.glue_job_max_retries
   timeout                = var.glue_job_timeout


### PR DESCRIPTION
Added glue job execution_class support which required terraform aws provider version 4.26.0